### PR TITLE
Fix/384 broken selenium tests

### DIFF
--- a/tests/walkthrough.page_creation.php
+++ b/tests/walkthrough.page_creation.php
@@ -29,12 +29,6 @@ class CreatePage extends WalkhubSeleniumTestCase {
     $element->clear();
     $element->value($title);
 
-    // setElementText
-    $element = $this->byId("edit-body-und-0-value");
-    $element->click();
-    $element->clear();
-    $element->value($body);
-
     // clickElement
     $this->byId("edit-submit")->click();
 


### PR DESCRIPTION
Remove filling in Page node body, because it does not work with the wysiwyg editor
