### PR TITLE
Revert "Enable walkthrough_sharelink module on site install and update"

### DIFF
--- a/profiles/walkthrough/walkthrough.info
+++ b/profiles/walkthrough/walkthrough.info
@@ -79,4 +79,3 @@ dependencies[] = walkhub_client
 dependencies[] = walkhub_screening_queue
 dependencies[] = walkhub_tcard
 dependencies[] = walkthrough_slideshow
-dependencies[] = walkthrough_sharelink

--- a/sites/all/modules/features/walkthrough_global/walkthrough_global.install
+++ b/sites/all/modules/features/walkthrough_global/walkthrough_global.install
@@ -890,12 +890,3 @@ function walkthrough_global_update_7061() {
 function walkthrough_global_update_7062() {
   walkhub_features_revert(array('walkthrough_permissions'));
 }
-
-/**
- * Enable walkthrough_sharelink module.
- */
-function walkthrough_global_update_7063() {
-  module_enable(array('walkthrough_sharelink'));
-  return 'Enabled Walkthrough sharelink module.';
-}
-


### PR DESCRIPTION
Waiting for some Ux improvements
